### PR TITLE
Show correct view for existing event/slot

### DIFF
--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -95,10 +95,11 @@
 				<button class="close-btn" @click="cancel"></button>
 			</div>
 
-			<PropertyCalendarPicker v-if="showCalendarPicker && isNew"
+			<PropertyCalendarPicker v-if="showCalendarPicker"
 				:calendars="calendars"
 				:calendar="selectedCalendar"
 				:is-read-only="isReadOnly"
+				:class="{ 'display-none' : !isNew }"
 				@select-calendar="changeCalendar"
 				@switch-calendar="isSlotCheck"
 				@current-calendar="isSlotCheck" />
@@ -536,6 +537,10 @@ export default {
 		display: flex;
 		padding-right: 1rem;
 		opacity: 1 !important;
+	}
+
+	.display-none{
+		display: none;
 	}
 }
 

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -99,7 +99,7 @@
 				:calendars="calendars"
 				:calendar="selectedCalendar"
 				:is-read-only="isReadOnly"
-				:class="{ 'display-none' : !isNew }"
+				:class="{ 'hidden' : !isNew }"
 				@select-calendar="changeCalendar"
 				@switch-calendar="isSlotCheck"
 				@current-calendar="isSlotCheck" />
@@ -539,7 +539,7 @@ export default {
 		opacity: 1 !important;
 	}
 
-	.display-none{
+	.hidden{
 		display: none;
 	}
 }


### PR DESCRIPTION
The event view was showing up for an existing slot, I've found out that it was caused by removing the calendar picker from an existing event. I've tried to retrieve the calendar from the selected event but with no luck so adding a display none to the selector when we have an existing event/slot was a quick fix.