### PR TITLE
Disable "All Day" on creating slots 

### DIFF
--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -26,7 +26,8 @@
 	<div class="property-title-time-picker">
 		<div v-if="!isReadOnly"
 			class="property-title-time-picker__time-pickers">
-			<DatePicker :date="startDate"
+			<DatePicker :key="startDateKey"
+				:date="startDate"
 				:timezone-id="startTimezone"
 				prefix="from"
 				:is-all-day="isAllDay"
@@ -35,7 +36,8 @@
 				@change="changeStart"
 				@change-timezone="changeStartTimezone" />
 
-			<DatePicker :date="endDate"
+			<DatePicker :key="endDateKey"
+				:date="endDate"
 				:timezone-id="endTimezone"
 				prefix="to"
 				:is-all-day="isAllDay"
@@ -171,6 +173,8 @@ export default {
 		return {
 			showStartTimezone: false,
 			showEndTimezone: false,
+			startDateKey: 0,
+			endDateKey: 1,
 		}
 	},
 	computed: {
@@ -242,10 +246,19 @@ export default {
 	},
 	watch: {
 		isSlot() {
-			if(this.isSlot){
-				this.$store.state.calendarObjectInstance.calendarObjectInstance.isAllDay = false;
+			if (this.isSlot) {
+				this.$store.state.calendarObjectInstance.calendarObjectInstance.isAllDay = false
+				if (this.startDate.getHours() === 0) {
+					this.$store.state.calendarObjectInstance.calendarObjectInstance.startDate.isDate = true
+					this.$store.state.calendarObjectInstance.calendarObjectInstance.startDate.setHours('10')
+					this.$store.state.calendarObjectInstance.calendarObjectInstance.endDate.isDate = true
+					this.$store.state.calendarObjectInstance.calendarObjectInstance.endDate.setHours('11')
+					// Force update the date pickers
+					this.startDateKey++
+					this.endDateKey++
+				}
 			}
-		}
+		},
 	},
 	methods: {
 		/**

--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -66,7 +66,7 @@
 			</div>
 		</div>
 
-		<div v-if="!isReadOnly" class="property-title-time-picker__all-day">
+		<div v-if="!isReadOnly && !isSlot" class="property-title-time-picker__all-day">
 			<input id="allDay"
 				:checked="isAllDay"
 				type="checkbox"
@@ -159,6 +159,13 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * Whether or not the event is a slot
+		 */
+		isSlot: {
+			type: Boolean,
+			required: true,
+		},
 	},
 	data() {
 		return {
@@ -232,6 +239,13 @@ export default {
 		highlightEndTimezone() {
 			return this.endTimezone !== this.userTimezone
 		},
+	},
+	watch: {
+		isSlot() {
+			if(this.isSlot){
+				this.$store.state.calendarObjectInstance.calendarObjectInstance.isAllDay = false;
+			}
+		}
 	},
 	methods: {
 		/**

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -114,6 +114,7 @@
 				:end-date="endDate"
 				:end-timezone="endTimezone"
 				:is-all-day="isAllDay"
+				:is-slot="isSlot"
 				:is-read-only="isReadOnly"
 				:can-modify-all-day="canModifyAllDay"
 				:user-timezone="currentUserTimezone"
@@ -125,12 +126,11 @@
 
 			<PropertyClientPicker :is-read-only="isReadOnly"
 				:calendar-object-instance="calendarObjectInstance"
-				:is-slot="isSlot"/>
+				:is-slot="isSlot" />
 
 			<PropertyTalkButton :calendar-object-instance="calendarObjectInstance"
 				:is-read-only="isReadOnly"
-				:is-slot="isSlot"
-			/>
+				:is-slot="isSlot" />
 
 			<PropertyText v-if="!isSlot"
 				:is-read-only="isReadOnly"


### PR DESCRIPTION
### Changes

Disables the is all day checkbox for slots in the calendar and sets it to false

### Testing

Create or modify a new slot and the is all day should not be displayed. Also when switching from event to slot, if the is all day was checked, the popup should have time displayed in the start and end dates like the screenshot below 

### Screenshot

![image](https://user-images.githubusercontent.com/29747887/196229566-bb6eb135-d26d-4349-a46a-b76b7fa3f076.png)
