### PR TITLE
Fix Appointment slots created without first ticking "All day" checkbox aren't seen as valid slots

### DIFF
--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -247,7 +247,9 @@ export default {
 	watch: {
 		isSlot() {
 			if (this.isSlot) {
-				this.$store.state.calendarObjectInstance.calendarObjectInstance.isAllDay = false
+				if (this.$store.state.calendarObjectInstance.calendarObjectInstance.isAllDay) {
+					this.toggleAllDay()
+				}
 				if (this.startDate.getHours() === 0) {
 					this.$store.state.calendarObjectInstance.calendarObjectInstance.startDate.isDate = true
 					this.$store.state.calendarObjectInstance.calendarObjectInstance.startDate.setHours('10')


### PR DESCRIPTION
### Changes

Use method to disable allDay variable

### Testing

1. Open the calendar month view and click a day to create an event
2. Make sure the all day checkbox is ticked 
3. Change from event to slot
4. Check if the new slot shows up in the booking widget

